### PR TITLE
Add validation of api_type variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -55,4 +55,8 @@ variable "subscription_required" {
 variable "api_type" {
   description = "Type of API. Possible values are graphql, http, soap, and websocket. (Default: http)"
   default     = "http"
+  validation {
+    condition     = contains(["graphql", "http", "soap", "websocket"], var.api_type)
+    error_message = "API Type possible values are graphql, http, soap and websocket."
+  }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Building on the changes made for #14, add validation to ensure that the api_type can only be one of the expected values - see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api#api_type.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
